### PR TITLE
update: version of bigdecimal. because of warning.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       mutex_m
       tzinfo (~> 2.0)
     base64 (0.2.0)
-    bigdecimal (1.4.4)
+    bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)


### PR DESCRIPTION
## summary
update version of BigDecimal.

## warning message.
> /usr/local/bundle/gems/bigdecimal-1.4.4/lib/bigdecimal.so: warning: undefining the allocator of T_DATA class BigDecimal